### PR TITLE
Add standalone map component demo

### DIFF
--- a/map-demo/App.tsx
+++ b/map-demo/App.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import ListingsMap, { Listing } from './components/ListingsMap';
+import listings from './assets/sample-listings.json';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <ListingsMap listingData={listings as Listing[]} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});

--- a/map-demo/README.md
+++ b/map-demo/README.md
@@ -1,0 +1,16 @@
+# Map Demo
+
+This folder contains a minimal Expo project showcasing the map components used in the main app.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm start
+   ```
+
+The demo renders a map with a few sample listings from `assets/sample-listings.json`.

--- a/map-demo/app.json
+++ b/map-demo/app.json
@@ -1,0 +1,9 @@
+{
+  "expo": {
+    "name": "MapDemo",
+    "slug": "map-demo",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "assetBundlePatterns": ["**/*"]
+  }
+}

--- a/map-demo/assets/sample-listings.json
+++ b/map-demo/assets/sample-listings.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": 1,
+    "host_id": 101,
+    "latitude": 41.3851,
+    "longitude": 2.1734,
+    "price": "$120"
+  },
+  {
+    "id": 2,
+    "host_id": 102,
+    "latitude": 41.386,
+    "longitude": 2.1744,
+    "price": "$150"
+  },
+  {
+    "id": 3,
+    "host_id": 103,
+    "latitude": 41.387,
+    "longitude": 2.1754,
+    "price": "$90"
+  }
+]

--- a/map-demo/babel.config.js
+++ b/map-demo/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ["babel-preset-expo"],
+    plugins: ["react-native-reanimated/plugin"],
+  };
+};

--- a/map-demo/components/ListingsMap.tsx
+++ b/map-demo/components/ListingsMap.tsx
@@ -1,0 +1,164 @@
+import React, { memo, useCallback, useEffect, useRef } from "react";
+import { View, Text, StyleSheet } from "react-native";
+import MapView, { Marker, PROVIDER_DEFAULT } from "react-native-map-clustering";
+import { Ionicons } from "@expo/vector-icons";
+import { defaultStyles } from "../constants/Styles";
+import Colors from "../constants/Colors";
+
+export interface Listing {
+  id: number;
+  host_id: number;
+  latitude: number;
+  longitude: number;
+  price: string;
+}
+
+interface Props {
+  listingData: Listing[];
+  onMarkerPress?: (item: Listing) => void;
+}
+
+const INITIAL_REGION = {
+  latitude: 41.3851,
+  longitude: 2.1734,
+  latitudeDelta: 0.0922,
+  longitudeDelta: 0.0421,
+};
+
+const debouncedRenderMarkers = (
+  data: Listing[],
+  setDebouncedListingData: React.Dispatch<React.SetStateAction<Listing[]>>
+) => {
+  let timerId: ReturnType<typeof setTimeout> | null = null;
+
+  return () => {
+    if (timerId) {
+      clearTimeout(timerId);
+    }
+    timerId = setTimeout(() => {
+      setDebouncedListingData(data);
+    }, 100);
+    return () => {
+      if (timerId) {
+        clearTimeout(timerId);
+      }
+    };
+  };
+};
+
+const ListingsMap = memo(({ listingData, onMarkerPress }: Props) => {
+  const listingDataRef = useRef<Listing[]>(listingData);
+  const [debouncedListingData, setDebouncedListingData] = React.useState<Listing[]>([]);
+  const debouncedRender = useCallback(
+    debouncedRenderMarkers(listingDataRef.current, setDebouncedListingData),
+    [setDebouncedListingData]
+  );
+
+  useEffect(() => {
+    listingDataRef.current = listingData;
+    const cleanup = debouncedRender();
+    return cleanup;
+  }, [listingData, debouncedRender]);
+
+  const renderCluster = (cluster: any) => {
+    const { id, properties, geometry, onPress } = cluster;
+    const points = properties.point_count;
+
+    return (
+      <Marker
+        key={id}
+        onPress={onPress}
+        coordinate={{
+          longitude: geometry.coordinates[0],
+          latitude: geometry.coordinates[1],
+        }}
+      >
+        <View style={styles.cluster}>
+          <Text style={{ fontFamily: "mon-sb", fontSize: 14 }}>{points}</Text>
+        </View>
+      </Marker>
+    );
+  };
+
+  const handleMarkerPress = (item: Listing) => {
+    if (onMarkerPress) {
+      onMarkerPress(item);
+    }
+  };
+
+  return (
+    <View style={defaultStyles.container}>
+      <MapView
+        animationEnabled={false}
+        style={StyleSheet.absoluteFill}
+        initialRegion={INITIAL_REGION}
+        showsUserLocation
+        showsMyLocationButton
+        provider={PROVIDER_DEFAULT}
+        clusterColor="#fff"
+        clusterTextColor="#000"
+        clusterFontFamily="mon-sb"
+        renderCluster={renderCluster}
+      >
+        {debouncedListingData.map((item) => (
+          <Marker
+            key={`${item.id}${item.host_id}`}
+            coordinate={{
+              latitude: item.latitude,
+              longitude: item.longitude,
+            }}
+            onPress={() => handleMarkerPress(item)}
+          >
+            <View style={styles.marker}>
+              <Ionicons name="location" size={20} color={Colors.primary} />
+              <Text style={styles.markerText}>{item.price || "$N/A"}</Text>
+            </View>
+          </Marker>
+        ))}
+      </MapView>
+    </View>
+  );
+});
+
+export default ListingsMap;
+
+const styles = StyleSheet.create({
+  marker: {
+    flexDirection: "row",
+    justifyContent: "center",
+    alignItems: "center",
+    gap: 3,
+    backgroundColor: "#fff",
+    borderRadius: 10,
+    borderColor: "#A3A3A3",
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 6,
+    elevation: 5,
+    shadowColor: "#000",
+    shadowOpacity: 0.3,
+    shadowRadius: 6,
+    shadowOffset: {
+      width: 1,
+      height: 10,
+    },
+  },
+  markerText: {
+    fontSize: 14,
+    fontFamily: "mon-sb",
+  },
+  cluster: {
+    backgroundColor: "#fff",
+    justifyContent: "center",
+    alignItems: "center",
+    borderRadius: 50,
+    padding: 8,
+    elevation: 5,
+    shadowColor: "#000",
+    shadowOpacity: 0.3,
+    shadowRadius: 6,
+    shadowOffset: {
+      width: 1,
+      height: 10,
+    },
+  },
+});

--- a/map-demo/constants/Colors.ts
+++ b/map-demo/constants/Colors.ts
@@ -1,0 +1,6 @@
+export default {
+  primary: "#FF5A5F",
+  grey: "#5E5D5E",
+  darkGrey: "#878787",
+  dark: "#1A1A1A",
+};

--- a/map-demo/constants/Styles.ts
+++ b/map-demo/constants/Styles.ts
@@ -1,0 +1,45 @@
+import { StyleSheet } from "react-native";
+import Colors from "./Colors";
+
+export const defaultStyles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#FDFFFF",
+  },
+  inputField: {
+    height: 58,
+    borderWidth: 1,
+    borderColor: "#ABABAB",
+    borderRadius: 8,
+    padding: 10,
+    backgroundColor: "#fff",
+  },
+  btn: {
+    backgroundColor: Colors.primary,
+    height: 62,
+    borderRadius: 8,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  btnText: {
+    color: "#fff",
+    fontSize: 16,
+    fontFamily: "mon-b",
+  },
+  btnIcon: {
+    position: "absolute",
+    left: 16,
+  },
+  footer: {
+    position: "absolute",
+    height: 100,
+    bottom: 0,
+    left: 0,
+    right: 0,
+    backgroundColor: "#fff",
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    borderTopColor: Colors.grey,
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+});

--- a/map-demo/package.json
+++ b/map-demo/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "map-demo",
+  "version": "1.0.0",
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^51.0.14",
+    "react": "18.2.0",
+    "react-native": "0.74.2",
+    "react-native-map-clustering": "^3.4.2",
+    "react-native-maps": "1.14.0",
+    "@expo/vector-icons": "^14.0.0"
+  }
+}

--- a/map-demo/tsconfig.json
+++ b/map-demo/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true
+  },
+  "include": ["**/*.ts", "**/*.tsx"]
+}


### PR DESCRIPTION
## Summary
- add `map-demo` folder with a minimal Expo project
- extract map logic into a reusable `ListingsMap` component
- include sample listing data and basic configuration files

## Testing
- `npm test` *(fails: jest not found due to environment restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6860ba346748832f904510dda1a03cc7